### PR TITLE
Update Flake and Cargo locks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ http = "1.2"
 rand = "0.9"
 thiserror = "2.0"
 tracing = { version = "0.1" }
-hickory-resolver = { version = "0.25" }
+hickory-resolver = { version = "0.26" }
 url = "2.5.4"
 
 [dev-dependencies]

--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1738391509,
-        "narHash": "sha256-TC3xA++KgprECm/WPsLUd+a77MObZPElCW6eAsjVW1k=",
-        "rev": "de3ea31eb651b663449361f77d9c1e8835290470",
-        "revCount": 2156,
+        "lastModified": 1777624102,
+        "narHash": "sha256-thSyElkje577x/kAbP72nHlfiFc1a+tCudskLPHXe9s=",
+        "rev": "4d81601e0b73f20d81d066754ad0e7d1e7f75a06",
+        "revCount": 2646,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2156%2Brev-de3ea31eb651b663449361f77d9c1e8835290470/0194c095-0041-7b9c-b19e-cf1c4a2adaad/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2646%2Brev-4d81601e0b73f20d81d066754ad0e7d1e7f75a06/019de2eb-4157-78e2-99a4-47e0ab7416f5/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/fenix/0.1.1584.tar.gz"
+        "url": "https://flakehub.com/f/nix-community/fenix/0"
       }
     },
     "naersk": {
@@ -42,16 +42,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738546358,
-        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
-        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
-        "revCount": 747070,
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "revCount": 912297,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.747070%2Brev-c6e957d81b96751a3d5967a0fd73694f303cc914/0194cfda-968b-7c4f-95c5-bd4a42478770/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.912297%2Brev-0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5/019dfbf4-87c2-7d91-9a98-ccf8f9b548eb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.590113.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0"
       }
     },
     "root": {
@@ -64,11 +64,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1738224931,
-        "narHash": "sha256-1zhfA5NBqin0Z79Se85juvqQteq7uClJMEb7l2pdDUY=",
+        "lastModified": 1777583169,
+        "narHash": "sha256-dVJ4+wrRKc8oIgp3rLOFSq1obt/sCKlXy3h47qof/w0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3c2aca1e5e9fbabb4e05fc4baa62e807aadc476a",
+        "rev": "aa64e4828a2bbba44463c1229a81c748d3cce583",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "detsys-srv";
 
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.590113.tar.gz";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
 
     fenix = {
-      url = "https://flakehub.com/f/nix-community/fenix/0.1.1584.tar.gz";
+      url = "https://flakehub.com/f/nix-community/fenix/0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/src/resolver/hickory.rs
+++ b/src/resolver/hickory.rs
@@ -4,7 +4,9 @@ use super::SrvResolver;
 use crate::SrvRecord;
 use async_trait::async_trait;
 use hickory_resolver::{
-    name_server::ConnectionProvider, proto::rr::rdata::SRV, Name, ResolveError, Resolver,
+    net::NetError,
+    proto::rr::{rdata::SRV, Name, RData},
+    ConnectionProvider, Resolver,
 };
 use std::time::Instant;
 
@@ -14,15 +16,23 @@ where
     P: ConnectionProvider,
 {
     type Record = SRV;
-    type Error = ResolveError;
+    type Error = NetError;
 
     async fn get_srv_records_unordered(
         &self,
         srv: &str,
     ) -> Result<(Vec<Self::Record>, Instant), Self::Error> {
         let lookup = self.srv_lookup(srv).await?;
-        let valid_until = lookup.as_lookup().valid_until();
-        Ok((lookup.into_iter().collect(), valid_until))
+        let valid_until = lookup.valid_until();
+        let records = lookup
+            .answers()
+            .iter()
+            .filter_map(|record| match &record.data {
+                RData::SRV(srv) => Some(srv.clone()),
+                _ => None,
+            })
+            .collect();
+        Ok((records, valid_until))
     }
 }
 
@@ -30,19 +40,19 @@ impl SrvRecord for SRV {
     type Target = Name;
 
     fn target(&self) -> &Self::Target {
-        self.target()
+        &self.target
     }
 
     fn port(&self) -> u16 {
-        self.port()
+        self.port
     }
 
     fn priority(&self) -> u16 {
-        self.priority()
+        self.priority
     }
 
     fn weight(&self) -> u16 {
-        self.weight()
+        self.weight
     }
 }
 
@@ -58,9 +68,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn srv_lookup() -> Result<(), ResolveError> {
+    async fn srv_lookup() -> Result<(), NetError> {
         let (records, _) = Resolver::builder_tokio()?
-            .build()
+            .build()?
             .get_srv_records_unordered(EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);
@@ -68,9 +78,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn srv_lookup_ordered() -> Result<(), ResolveError> {
+    async fn srv_lookup_ordered() -> Result<(), NetError> {
         let (records, _) = Resolver::builder_tokio()?
-            .build()
+            .build()?
             .get_srv_records(EXAMPLE_SRV)
             .await?;
         assert_ne!(records.len(), 0);
@@ -79,8 +89,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_fresh_uris() -> Result<(), ResolveError> {
-        let resolver = Resolver::builder_tokio()?.build();
+    async fn get_fresh_uris() -> Result<(), NetError> {
+        let resolver = Resolver::builder_tokio()?.build()?;
         let client = crate::SrvClient::<_>::new_with_resolver(
             EXAMPLE_SRV,
             example_fallback(),
@@ -97,6 +107,7 @@ mod tests {
         Resolver::builder_tokio()
             .unwrap()
             .build()
+            .unwrap()
             .get_srv_records("_http._tcp.foobar.deshaw.com")
             .await
             .unwrap_err();
@@ -107,6 +118,7 @@ mod tests {
         Resolver::builder_tokio()
             .unwrap()
             .build()
+            .unwrap()
             .get_srv_records("_http.foobar.deshaw.com")
             .await
             .unwrap_err();
@@ -117,6 +129,7 @@ mod tests {
         Resolver::builder_tokio()
             .unwrap()
             .build()
+            .unwrap()
             .get_srv_records("  @#*^[_hsd flt.com")
             .await
             .unwrap_err();
@@ -127,6 +140,7 @@ mod tests {
         Resolver::builder_tokio()
             .unwrap()
             .build()
+            .unwrap()
             .get_srv_records("_http.\0_tcp.foo.com")
             .await
             .unwrap_err();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated hickory-resolver dependency to version 0.26.
  * Adjusted Nix flake inputs for nixpkgs and fenix to use flexible, non-tarball URLs for easier updates and pinning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->